### PR TITLE
Add SetLightPower 117 request

### DIFF
--- a/light/device.go
+++ b/light/device.go
@@ -35,6 +35,21 @@ type Device interface {
 	// device.
 	SetColor(ctx context.Context, conn net.Conn, color *lifxlan.Color, transition time.Duration, ack bool) error
 
+	// SetLightPower set the power level of the device and specify how long it
+	// will take to transition to the new power state.
+	//
+	// If conn is nil,
+	// a new connection will be made and guaranteed to be closed before returning.
+	// You should pre-dial and pass in the conn if you plan to call APIs on this
+	// device repeatedly.
+	//
+	// If ack is false,
+	// this function returns nil error after the API is sent successfully.
+	// If ack is true,
+	// this function will only return nil error after it received ack from the
+	// device.
+	SetLightPower(ctx context.Context, conn net.Conn, power lifxlan.Power, transition time.Duration, ack bool) error
+
 	// SetWaveform sends SetWaveformOptional message as defined in
 	//
 	// https://lan.developer.lifx.com/docs/light-messages#section-setwaveformoptional-119

--- a/light/device.go
+++ b/light/device.go
@@ -35,7 +35,7 @@ type Device interface {
 	// device.
 	SetColor(ctx context.Context, conn net.Conn, color *lifxlan.Color, transition time.Duration, ack bool) error
 
-	// SetLightPower set the power level of the device and specify how long it
+	// SetLightPower sets the power level of the device and specifies how long it
 	// will take to transition to the new power state.
 	//
 	// If conn is nil,

--- a/light/messages.go
+++ b/light/messages.go
@@ -9,5 +9,6 @@ const (
 	Get                 lifxlan.MessageType = 101
 	SetColor            lifxlan.MessageType = 102
 	State               lifxlan.MessageType = 107
+	SetLightPower       lifxlan.MessageType = 117
 	SetWaveformOptional lifxlan.MessageType = 119
 )

--- a/light/power.go
+++ b/light/power.go
@@ -1,0 +1,67 @@
+package light
+
+import (
+	"context"
+	"net"
+	"time"
+
+	"go.yhsif.com/lifxlan"
+)
+
+// RawSetLightPowerPayload defines the struct to be used for encoding and decoding.
+//
+// https://lan.developer.lifx.com/docs/changing-a-device#setlightpower---packet-117
+type RawSetLightPowerPayload struct {
+	Level    lifxlan.Power
+	Duration lifxlan.TransitionTime
+}
+
+func (ld *device) SetLightPower(
+	ctx context.Context,
+	conn net.Conn,
+	power lifxlan.Power,
+	transition time.Duration,
+	ack bool,
+) error {
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+
+	if conn == nil {
+		newConn, err := ld.Dial()
+		if err != nil {
+			return err
+		}
+		defer newConn.Close()
+		conn = newConn
+
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+	}
+
+	var flags lifxlan.AckResFlag
+	if ack {
+		flags |= lifxlan.FlagAckRequired
+	}
+
+	// Send
+	seq, err := ld.Send(
+		ctx,
+		conn,
+		flags,
+		SetLightPower,
+		&RawSetLightPowerPayload{
+			Level:    power,
+			Duration: lifxlan.ConvertDuration(transition),
+		},
+	)
+	if err != nil {
+		return err
+	}
+
+	if ack {
+		return lifxlan.WaitForAcks(ctx, conn, ld.Source(), seq)
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary
This implements sending a SetLightPower request as specified in the [LIFX LAN protocol documentation](https://lan.developer.lifx.com/docs/changing-a-device#setlightpower---packet-117). This functionality is important because, while SetColor can define brightness and transition period, it doesn't actually turn the bulb on.

## Notes
While the SetLightPower message does return a StateLightPower response, we aren't listening to responses from SetColor or SetPower, so I omitted that functionality from SetLightPower.