### PR TITLE
Add EchoRequest and EchoResponse

### DIFF
--- a/device.go
+++ b/device.go
@@ -107,7 +107,7 @@ type Device interface {
 	// a new connection will be made and guaranteed to be closed before returning.
 	// You should pre-dial and pass in the conn if you plan to call APIs on this
 	// device repeatedly.
-	Echo(ctx context.Context, conn net.Conn) error
+	Echo(ctx context.Context, conn net.Conn, payload []byte) error
 
 	// GetPower returns the current power level of the device.
 	//

--- a/device.go
+++ b/device.go
@@ -101,7 +101,9 @@ type Device interface {
 	SanitizeColor(color Color) Color
 
 	// Echo sends a message to the device and waits for a response to ensure that
-	// the device is online and responding
+	// the device is online and responding. A payload can optionally be provided
+	// to define the data that is sent to the device and expected to be returned
+	// in the echo response.
 	//
 	// If conn is nil,
 	// a new connection will be made and guaranteed to be closed before returning.

--- a/device.go
+++ b/device.go
@@ -100,6 +100,15 @@ type Device interface {
 	// upgrades).
 	SanitizeColor(color Color) Color
 
+	// Echo sends a message to the device and waits for a response to ensure that
+	// the device is online and responding
+	//
+	// If conn is nil,
+	// a new connection will be made and guaranteed to be closed before returning.
+	// You should pre-dial and pass in the conn if you plan to call APIs on this
+	// device repeatedly.
+	Echo(ctx context.Context, conn net.Conn) error
+
 	// GetPower returns the current power level of the device.
 	//
 	// If conn is nil,

--- a/echo.go
+++ b/echo.go
@@ -1,0 +1,75 @@
+package lifxlan
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"errors"
+	"math/rand"
+	"net"
+)
+
+type RawEchoResponsePayload struct {
+	Echoing [64]byte
+}
+
+func (d *device) Echo(ctx context.Context, conn net.Conn) error {
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+
+	if conn == nil {
+		newConn, err := d.Dial()
+		if err != nil {
+			return err
+		}
+		defer newConn.Close()
+		conn = newConn
+
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+	}
+
+	payload := make([]byte, 0, 64)
+	rand.Read(payload)
+
+	seq, err := d.Send(
+		ctx,
+		conn,
+		0, // flags
+		EchoRequest,
+		payload,
+	)
+	if err != nil {
+		return err
+	}
+
+	for {
+		resp, err := ReadNextResponse(ctx, conn)
+		if err != nil {
+			return err
+		}
+		if resp.Sequence != seq || resp.Source != d.Source() {
+			continue
+		}
+		if resp.Message != EchoResponse {
+			continue
+		}
+
+		var raw RawEchoResponsePayload
+		r := bytes.NewReader(resp.Payload)
+		if err := binary.Read(r, binary.LittleEndian, &raw); err != nil {
+			return err
+		}
+
+		var expected [64]byte
+		copy(expected[:], payload)
+
+		if raw.Echoing != expected {
+			return errors.New("unexpected echo response value")
+		}
+
+		return nil
+	}
+}

--- a/echo.go
+++ b/echo.go
@@ -73,10 +73,7 @@ func (d *device) Echo(ctx context.Context, conn net.Conn, payload []byte) error 
 			return err
 		}
 
-		var expected [EchoPayloadLength]byte
-		copy(expected[:], body)
-
-		if raw.Echoing != expected {
+		if !bytes.Equal(raw.Echoing[:], body) {
 			return errors.New("unexpected echo response value")
 		}
 

--- a/echo.go
+++ b/echo.go
@@ -9,11 +9,15 @@ import (
 	"net"
 )
 
+const (
+	EchoPayloadLength = 64
+)
+
 // RawEchoResponsePayload defines echo response payload according to:
 //
 // https://lan.developer.lifx.com/docs/information-messages#echoresponse---packet-59
 type RawEchoResponsePayload struct {
-	Echoing [64]byte
+	Echoing [EchoPayloadLength]byte
 }
 
 func (d *device) Echo(ctx context.Context, conn net.Conn) error {
@@ -34,7 +38,7 @@ func (d *device) Echo(ctx context.Context, conn net.Conn) error {
 		}
 	}
 
-	payload := make([]byte, 64)
+	payload := make([]byte, EchoPayloadLength)
 	rand.Read(payload)
 
 	seq, err := d.Send(
@@ -66,7 +70,7 @@ func (d *device) Echo(ctx context.Context, conn net.Conn) error {
 			return err
 		}
 
-		var expected [64]byte
+		var expected [EchoPayloadLength]byte
 		copy(expected[:], payload)
 
 		if raw.Echoing != expected {

--- a/echo.go
+++ b/echo.go
@@ -9,6 +9,9 @@ import (
 	"net"
 )
 
+// RawEchoResponsePayload defines echo response payload according to:
+//
+// https://lan.developer.lifx.com/docs/information-messages#echoresponse---packet-59
 type RawEchoResponsePayload struct {
 	Echoing [64]byte
 }

--- a/echo.go
+++ b/echo.go
@@ -31,7 +31,7 @@ func (d *device) Echo(ctx context.Context, conn net.Conn) error {
 		}
 	}
 
-	payload := make([]byte, 0, 64)
+	payload := make([]byte, 64)
 	rand.Read(payload)
 
 	seq, err := d.Send(

--- a/echo.go
+++ b/echo.go
@@ -20,7 +20,7 @@ type RawEchoResponsePayload struct {
 	Echoing [EchoPayloadLength]byte
 }
 
-func (d *device) Echo(ctx context.Context, conn net.Conn) error {
+func (d *device) Echo(ctx context.Context, conn net.Conn, payload []byte) error {
 	if ctx.Err() != nil {
 		return ctx.Err()
 	}
@@ -38,15 +38,16 @@ func (d *device) Echo(ctx context.Context, conn net.Conn) error {
 		}
 	}
 
-	payload := make([]byte, EchoPayloadLength)
-	rand.Read(payload)
+	body := make([]byte, EchoPayloadLength)
+	rand.Read(body)
+	copy(body, payload)
 
 	seq, err := d.Send(
 		ctx,
 		conn,
 		0, // flags
 		EchoRequest,
-		payload,
+		body,
 	)
 	if err != nil {
 		return err
@@ -71,7 +72,7 @@ func (d *device) Echo(ctx context.Context, conn net.Conn) error {
 		}
 
 		var expected [EchoPayloadLength]byte
-		copy(expected[:], payload)
+		copy(expected[:], body)
 
 		if raw.Echoing != expected {
 			return errors.New("unexpected echo response value")

--- a/echo.go
+++ b/echo.go
@@ -39,8 +39,10 @@ func (d *device) Echo(ctx context.Context, conn net.Conn, payload []byte) error 
 	}
 
 	body := make([]byte, EchoPayloadLength)
-	rand.Read(body)
 	copy(body, payload)
+	if len(payload) < EchoPayloadLength {
+		rand.Read(body[len(payload):])
+	}
 
 	seq, err := d.Send(
 		ctx,

--- a/echo_test.go
+++ b/echo_test.go
@@ -21,8 +21,23 @@ func TestEcho(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
-	err := device.Echo(ctx, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	t.Run(
+		"UserPayload",
+		func(t *testing.T) {
+			err := device.Echo(ctx, nil, []byte("payload"))
+			if err != nil {
+				t.Fatal(err)
+			}
+		},
+	)
+
+	t.Run(
+		"DefaultPayload",
+		func(t *testing.T) {
+			err := device.Echo(ctx, nil, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+		},
+	)
 }

--- a/echo_test.go
+++ b/echo_test.go
@@ -32,6 +32,16 @@ func TestEcho(t *testing.T) {
 	)
 
 	t.Run(
+		"OversizePayload",
+		func(t *testing.T) {
+			err := device.Echo(ctx, nil, []byte("this is a big string that's longer than the allowed 64 bytes for the echo payload"))
+			if err != nil {
+				t.Fatal(err)
+			}
+		},
+	)
+
+	t.Run(
 		"DefaultPayload",
 		func(t *testing.T) {
 			err := device.Echo(ctx, nil, nil)

--- a/echo_test.go
+++ b/echo_test.go
@@ -1,0 +1,42 @@
+package lifxlan_test
+
+import (
+	"context"
+	"math/rand"
+	"testing"
+	"time"
+
+	"go.yhsif.com/lifxlan"
+	"go.yhsif.com/lifxlan/mock"
+)
+
+func TestEcho(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
+
+	const timeout = time.Millisecond * 200
+
+	seed := int64(0xdeadbeef)
+	rand.Seed(seed)
+	expectedSlice := make([]byte, 0, 64)
+	rand.Read(expectedSlice)
+	rand.Seed(seed)
+
+	var expected [64]byte
+	copy(expected[:], expectedSlice)
+
+	service, device := mock.StartService(t)
+	defer service.Stop()
+	service.RawEchoResponsePayload = &lifxlan.RawEchoResponsePayload{
+		Echoing: expected,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	err := device.Echo(ctx, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/echo_test.go
+++ b/echo_test.go
@@ -2,11 +2,9 @@ package lifxlan_test
 
 import (
 	"context"
-	"math/rand"
 	"testing"
 	"time"
 
-	"go.yhsif.com/lifxlan"
 	"go.yhsif.com/lifxlan/mock"
 )
 
@@ -17,20 +15,8 @@ func TestEcho(t *testing.T) {
 
 	const timeout = time.Millisecond * 200
 
-	seed := int64(0xdeadbeef)
-	rand.Seed(seed)
-	expectedSlice := make([]byte, 0, 64)
-	rand.Read(expectedSlice)
-	rand.Seed(seed)
-
-	var expected [64]byte
-	copy(expected[:], expectedSlice)
-
 	service, device := mock.StartService(t)
 	defer service.Stop()
-	service.RawEchoResponsePayload = &lifxlan.RawEchoResponsePayload{
-		Echoing: expected,
-	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()

--- a/messages.go
+++ b/messages.go
@@ -19,4 +19,6 @@ const (
 	StateLabel        MessageType = 25
 	GetVersion        MessageType = 32
 	StateVersion      MessageType = 33
+	EchoRequest       MessageType = 58
+	EchoResponse      MessageType = 59
 )

--- a/mock/mock.go
+++ b/mock/mock.go
@@ -72,10 +72,14 @@ func DefaultHandlerFunc(
 
 	case lifxlan.EchoRequest:
 		buf := new(bytes.Buffer)
+		var echoing [64]byte
+		copy(echoing[:], orig.Payload)
 		if err := binary.Write(
 			buf,
 			binary.LittleEndian,
-			s.RawEchoResponsePayload,
+			&lifxlan.RawEchoResponsePayload{
+				Echoing: echoing,
+			},
 		); err != nil {
 			s.TB.Log(err)
 			return

--- a/mock/mock.go
+++ b/mock/mock.go
@@ -72,7 +72,7 @@ func DefaultHandlerFunc(
 
 	case lifxlan.EchoRequest:
 		buf := new(bytes.Buffer)
-		var echoing [64]byte
+		var echoing [lifxlan.EchoPayloadLength]byte
 		copy(echoing[:], orig.Payload)
 		if err := binary.Write(
 			buf,

--- a/mock/mock.go
+++ b/mock/mock.go
@@ -70,6 +70,18 @@ func DefaultHandlerFunc(
 		}
 		s.Reply(conn, addr, orig, lifxlan.StateVersion, buf.Bytes())
 
+	case lifxlan.EchoRequest:
+		buf := new(bytes.Buffer)
+		if err := binary.Write(
+			buf,
+			binary.LittleEndian,
+			s.RawEchoResponsePayload,
+		); err != nil {
+			s.TB.Log(err)
+			return
+		}
+		s.Reply(conn, addr, orig, lifxlan.EchoResponse, buf.Bytes())
+
 	case light.Get:
 		buf := new(bytes.Buffer)
 		if err := binary.Write(
@@ -171,6 +183,7 @@ type Service struct {
 	RawStatePayload             *light.RawStatePayload
 	RawStateDeviceChainPayload  *tile.RawStateDeviceChainPayload
 	RawStateTileState64Payloads []*tile.RawStateTileState64Payload
+	RawEchoResponsePayload      *lifxlan.RawEchoResponsePayload
 
 	// The service context.
 	//

--- a/mock/mock.go
+++ b/mock/mock.go
@@ -187,7 +187,6 @@ type Service struct {
 	RawStatePayload             *light.RawStatePayload
 	RawStateDeviceChainPayload  *tile.RawStateDeviceChainPayload
 	RawStateTileState64Payloads []*tile.RawStateTileState64Payload
-	RawEchoResponsePayload      *lifxlan.RawEchoResponsePayload
 
 	// The service context.
 	//


### PR DESCRIPTION
## Summary
This implements sending an [EchoRequest](https://lan.developer.lifx.com/docs/querying-the-device-for-data#echorequest---packet-58) and receiving an [EchoResponse](https://lan.developer.lifx.com/docs/information-messages#echoresponse---packet-59) as defined by the LIFX LAN protocol. I have found that GetPower and GetHardwareVersion are sometimes spotty and I'd like a method that allows me to make sure my devices are online without actually requesting information from the device.

## Notes
As implemented, `device.Echo` generates a random 64-byte array to send to the device and verifies that the echoed response matches what was sent. It could be a useful feature to specify the 64-byte array that is sent.

If a payload of 64 \x00 bytes is sent to a device, the device treats it as an empty payload. It then returns a default valued payload, which is not all \x00 values, and is therefore unexpected.